### PR TITLE
Fix broken mcmod.info

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,3 +11,5 @@ jobs:
   build-and-test:
     uses: GTNewHorizons/GTNH-Actions-Workflows/.github/workflows/build-and-test.yml@master
     secrets: inherit
+    with:
+      client-only: true

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -16,7 +16,7 @@
 		"parent": "",
 		"requiredMods": [],
 		"dependencies": [],
-		"dependants": [],
-		"useDependencyInformation": true
-	}
+		"dependants": []
+	}]
+}
 ]


### PR DESCRIPTION
There were some missing brackets, also use dependencies from the mod annotation instead of the empty list here.