### PR TITLE
Make the mod info header readable

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,7 +1,7 @@
 {
 	"modListVersion": 2,
 	"modList": [{
-		"modid": ${modId},
+		"modid": "${modId}",
 		"name": "${modName}",
 		"description": "Allows you to edit the mainmenu using json",
 		"version": "${modVersion}",

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,22 +1,19 @@
 [
 {
-	"modListVersion": 2,
-	"modList": [{
-		"modid": "${modId}",
-		"name": "${modName}",
-		"description": "Allows you to edit the mainmenu using json",
-		"version": "${modVersion}",
-		"mcversion": "${minecraftVersion}",
-		"url": "",
-		"updateUrl": "",
-		"authorList": ["lumien"],
-		"credits": "",
-		"logoFile": "",
-		"screenshots": [],
-		"parent": "",
-		"requiredMods": [],
-		"dependencies": [],
-		"dependants": []
-	}]
+	"modid": "${modId}",
+	"name": "${modName}",
+	"description": "Allows you to edit the mainmenu using json",
+	"version": "${modVersion}",
+	"mcversion": "${minecraftVersion}",
+	"url": "",
+	"updateUrl": "",
+	"authorList": ["lumien"],
+	"credits": "",
+	"logoFile": "",
+	"screenshots": [],
+	"parent": "",
+	"requiredMods": [],
+	"dependencies": [],
+	"dependants": []
 }
 ]

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,19 +1,20 @@
-[
 {
-	"modid": "${modId}",
-	"name": "${modName}",
-	"description": "Allows you to edit the mainmenu using json",
-	"version": "${modVersion}",
-	"mcversion": "${minecraftVersion}",
-	"url": "",
-	"updateUrl": "",
-	"authorList": ["lumien"],
-	"credits": "",
-	"logoFile": "",
-	"screenshots": [],
-	"parent": "",
-	"requiredMods": [],
-	"dependencies": [],
-	"dependants": []
+	"modListVersion": 2,
+	"modList": [{
+		"modid": "custommainmenu",
+		"name": "Custom Main Menu",
+		"description": "Allows you to edit the mainmenu using json",
+		"version": "1.11.1",
+		"mcversion": "1.7.10",
+		"url": "",
+		"updateUrl": "",
+		"authorList": ["lumien"],
+		"credits": "",
+		"logoFile": "",
+		"screenshots": [],
+		"parent": "",
+		"requiredMods": [],
+		"dependencies": [],
+		"dependants": []
+	}]
 }
-]

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,11 +1,11 @@
 {
 	"modListVersion": 2,
 	"modList": [{
-		"modid": "custommainmenu",
-		"name": "Custom Main Menu",
+		"modid": ${modId},
+		"name": "${modName}",
 		"description": "Allows you to edit the mainmenu using json",
-		"version": "1.11.1",
-		"mcversion": "1.7.10",
+		"version": "${modVersion}",
+		"mcversion": "${minecraftVersion}",
 		"url": "",
 		"updateUrl": "",
 		"authorList": ["lumien"],


### PR DESCRIPTION
Unless I am misunderstanding something, there is no "modpack" here. This strange format makes it difficult for launchers to understand what is going on, thereby treating it as an arbitrary junk file.