### PR TITLE
Fix shuffled menus on Java 17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -108,7 +108,7 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories.
+# Adds the GTNH maven, CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.16'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.22'
 }
 
 

--- a/src/main/java/lumien/custommainmenu/configuration/elements/Slideshow.java
+++ b/src/main/java/lumien/custommainmenu/configuration/elements/Slideshow.java
@@ -29,7 +29,6 @@ public class Slideshow extends Element {
     public void shuffle() {
         List<ITexture> list = Arrays.asList(this.ressources);
         Collections.shuffle(list);
-        this.ressources = (ITexture[]) list.toArray();
     }
 
     public void update() {


### PR DESCRIPTION
On java 17, the back cast fails. It's also unnecessary regardless as according to Arrays.asList()'s docs, changes made to the list are reflected in the array and vice versa.